### PR TITLE
code cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,41 +7,49 @@ const mongoose = require('mongoose');
 
 const Exchange = mongoose.model('Exchange', mongoose.Schema({
     last_update: Date,
-    rates: [{
-        currency_name: String,
-        currency_code: String,
-        rate: Number
-    }]
+    rates: []
 }));
 
-mongoose.connect(process.env.MONGO_CONNECTION_STRING).then(() => {});
+const UPDATE_INTERVAL = 1000 * 60 * 60 * 12; // 12hrs
+
+mongoose.connect(process.env.MONGO_CONNECTION_STRING, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useFindAndModify: false
+}).then().catch(console.error);
 
 app.use(cors());
 
-app.get('/', async (req, res) => {
-    let exchange = await Exchange.findOne();
-    if (!exchange || (new Date() - exchange.last_update) >= 1000 * 60 * 60 * 12) {
+app.get('/', async (req, res, next) => {
+    try {
+        let exchange = await Exchange.findOne();
+
+        // exists in db, and newer then X hours
+        if (exchange && (new Date() - exchange.last_update) < UPDATE_INTERVAL) {
+            return res.send(exchange.rates);
+        }
+
+        // fetch from api
         let resp = await axios.get(`https://api.getgeoapi.com/api/v2/currency/convert?api_key=${process.env.EXCHANGE_API_KEY}&from=USD`);
+        // convert rates object to array
         let data = resp.data;
-        let v = [];
-        Object.keys(data.rates).forEach(key => v.push({
+        let rates = Object.keys(data.rates).map(key => ({
             currency_name: data.rates[key].currency_name,
             rate: data.rates[key].rate,
             currency_code: key
         }));
 
-        if (!exchange) {
-            exchange = await Exchange.create({
-                last_update: new Date(),
-                rates: v
-            });
-        } else {
-            exchange.last_update = new Date();
-            exchange.rates = v;
-            await exchange.save();
-        }
+        // create or update the db with the new rates
+        exchange = await Exchange.findOneAndUpdate({},
+            { last_update: new Date(), rates },
+            { new: true, upsert: true });
+
+        return res.send(rates);
+
+    } catch (error) {
+        console.log(error.message);
+        next(error)
     }
-    res.send(exchange.rates);
 });
 
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
- Schema rates was changed to simple array, rather storing sub documents (which also generated _id) which is not needed
- move the 12hrs int into UPDATE_INTERVAL const
- use mongoose.connect updated flags
- use try/catch (to pass async/await errors to express default error handler via next(err) function)
- use findOneAndUpdate with upsert, which is create if not exists.
